### PR TITLE
Individual UDP node functionality complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ sdkconfig
 *.swp
 CMakeFiles/
 CMakeCache.txt
+main/config.h

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 build/
 sdkconfig.old
 sdkconfig
+*.swp
+CMakeFiles/
+CMakeCache.txt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# CSH Analytics—Embedded Team
+# CSHacked—Embedded Team
 
-This repo contains all source code and information pertaining to the configuration and operation of the embedded portion of CSH Analytics. It's basically nothing right now. It just scans the bluetooth airwaves and lists them onscreen. That somehow needs to be put into a database...
+This repo contains all source code and information pertaining to the configuration and operation of the embedded portion of CSHacked. It's basically nothing right now. It just scans the bluetooth airwaves and lists them onscreen. That somehow needs to be put into a database...
 
 Below, you'll find some (slightly modified) documentation from the repo this project was pulled from.
 

--- a/components/bluetooth/CMakeLists.txt
+++ b/components/bluetooth/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "bluetooth.c"
-                    REQUIRES bt freertos data
+                    REQUIRES bt freertos data udp wifi
                     INCLUDE_DIRS "include")

--- a/components/bluetooth/bluetooth.c
+++ b/components/bluetooth/bluetooth.c
@@ -207,21 +207,22 @@ void bt_app_gap_cb(esp_bt_gap_cb_event_t event, esp_bt_gap_cb_param_t *param)
 void bt_app_gap_start_up(void)
 {
     get_wifi_mac_str(identifier_mac);
+	char *dev_name = "ESP_GAP_INQUIRY";
+	esp_bt_dev_set_device_name(dev_name);
+	
+	/* register GAP callback function */
+	esp_bt_gap_register_callback(bt_app_gap_cb);
+	/* set discoverable and connectable mode, wait to be connected */
+	esp_bt_gap_set_scan_mode(ESP_BT_NON_CONNECTABLE, ESP_BT_NON_DISCOVERABLE);
+	
+	/* inititialize device information and status */
+	bt_app_gap_init();
+	    
     while (true) {
-	    char *dev_name = "ESP_GAP_INQRUIY";
-	    esp_bt_dev_set_device_name(dev_name);
-	    
-	    /* register GAP callback function */
-	    esp_bt_gap_register_callback(bt_app_gap_cb);
-	    
-	    /* set discoverable and connectable mode, wait to be connected */
-	    esp_bt_gap_set_scan_mode(ESP_BT_NON_CONNECTABLE, ESP_BT_NON_DISCOVERABLE);
-	    
-	    /* inititialize device information and status */
-	    bt_app_gap_init();
-	    
 	    ESP_LOGI(CSHA_TAG, "Begin inquiry");
-	    esp_bt_gap_start_discovery(ESP_BT_INQ_MODE_GENERAL_INQUIRY, 10, 0);
+	    // esp_bt_gap_start_discovery(ESP_BT_INQ_MODE_GENERAL_INQUIRY, 10, 0);
+	    esp_err_t discovery_result = esp_bt_gap_start_discovery(ESP_BT_INQ_MODE_GENERAL_INQUIRY, 10, 0);
+        ESP_LOGI(CSHA_TAG, "discovery result = %d", discovery_result);
 	    vTaskDelay(15000 / portTICK_PERIOD_MS);
     }
 }

--- a/components/bluetooth/bluetooth.c
+++ b/components/bluetooth/bluetooth.c
@@ -1,6 +1,5 @@
 #include "bluetooth.h"
 
-char wifi_mac_str[17];
 
 char *bda2str(esp_bd_addr_t bda, char *str, size_t size)
 {
@@ -19,7 +18,6 @@ char *uuid2str(esp_bt_uuid_t *uuid, char *str, size_t size)
     if (uuid == NULL || str == NULL) {
         return NULL;
     }
-
     if (uuid->len == 2 && size >= 5) {
         sprintf(str, "%04x", uuid->uuid.uuid16);
     } else if (uuid->len == 4 && size >= 9) {
@@ -95,17 +93,8 @@ void update_device_info(esp_bt_gap_cb_param_t *param)
 
     /* search for device with MAJOR service class as "rendering" in COD */
     app_gap_cb_t *p_dev = &m_dev_info;
-    //if (p_dev->dev_found && 0 != memcmp(param->disc_res.bda, p_dev->bda, ESP_BD_ADDR_LEN)) {
-    //    return;
-    //}
-
-    //if (!esp_bt_gap_is_valid_cod(cod) ||
-	//    (!(esp_bt_gap_get_cod_major_dev(cod) == ESP_BT_COD_MAJOR_DEV_PHONE) &&
-    //         !(esp_bt_gap_get_cod_major_dev(cod) == ESP_BT_COD_MAJOR_DEV_AV))) {
-    //    return;
-    //}
-
     memcpy(p_dev->bda, param->disc_res.bda, ESP_BD_ADDR_LEN);
+
     p_dev->dev_found = true;
     for (int i = 0; i < param->disc_res.num_prop; i++) {
         p = param->disc_res.prop + i;
@@ -134,10 +123,31 @@ void update_device_info(esp_bt_gap_cb_param_t *param)
         }
     }
 
-    //if (p_dev->eir && p_dev->bdname_len == 0) {
-        get_name_from_eir(p_dev->eir, p_dev->bdname, &p_dev->bdname_len); ESP_LOGI(CSHA_TAG, "Found a target device, address %s, name %s, RSSI %d", bda2str(param->disc_res.bda, bda_str, 18), p_dev->bdname, rssi); //p_dev->state = APP_GAP_STATE_DEVICE_DISCOVER_COMPLETE; // We never wanna stop //        ESP_LOGI(CSHA_TAG, "Cancel device discovery ...");
-//       esp_bt_gap_cancel_discovery();
-    //}
+    get_name_from_eir(p_dev->eir, p_dev->bdname, &p_dev->bdname_len); 
+
+    csha_bt_packet packet;
+
+    ESP_LOGI(CSHA_TAG, "Found a target device, address %s, name %s, RSSI %d", bda2str(param->disc_res.bda, bda_str, 18), p_dev->bdname, rssi);
+    
+    //copy bda string to bt packet
+    //packet.mac = bda_str;
+    sprintf(packet.mac, "%s", bda_str);
+    sprintf(packet.name, "%s",  p_dev->bdname);
+    packet.rssi = rssi;
+
+    int data_str_len = calc_len(&packet);
+    char data_str[data_str_len];
+
+    format_data(data_str, &packet);
+
+    if (socket_ready())
+    {
+        // ESP_LOGI(CSHA_TAG,"sending udp");
+        udp_send_str(data_str, MAX_SAFE_BLOCK_SIZE);
+    }
+    // ESP_LOGI(CSHA_TAG, "%s -- %d", data_str, data_str_len);
+
+    // ESP_LOGI(CSHA_TAG, "%d -- %d -- %d -- %d", data_str_len, strlen((&packet)->name), strlen((&packet)->mac), packet.rssi);
 }
 
 void bt_app_gap_init(void)
@@ -156,70 +166,69 @@ void bt_app_gap_cb(esp_bt_gap_cb_event_t event, esp_bt_gap_cb_param_t *param)
     char uuid_str[37];
 
     switch (event) {
-    case ESP_BT_GAP_DISC_RES_EVT: {
-        update_device_info(param);
-        break;
-    }
-    case ESP_BT_GAP_DISC_STATE_CHANGED_EVT: {
-        if (param->disc_st_chg.state == ESP_BT_GAP_DISCOVERY_STOPPED) {
-            ESP_LOGI(CSHA_TAG, "Device discovery stopped.");
-            //if ( (p_dev->state == APP_GAP_STATE_DEVICE_DISCOVER_COMPLETE ||
-            //        p_dev->state == APP_GAP_STATE_DEVICE_DISCOVERING)
-            //        && p_dev->dev_found) {
-            //    p_dev->state = APP_GAP_STATE_SERVICE_DISCOVERING;
-            //    ESP_LOGI(CSHA_TAG, "Discover services ...");
-            //    esp_bt_gap_get_remote_services(p_dev->bda);
-            //}
-        } else if (param->disc_st_chg.state == ESP_BT_GAP_DISCOVERY_STARTED) {
-            ESP_LOGI(CSHA_TAG, "Discovery started.");
+        case ESP_BT_GAP_DISC_RES_EVT: {
+            update_device_info(param);
+            break;
         }
-        break;
-    }
-    case ESP_BT_GAP_RMT_SRVCS_EVT: {
-        if (memcmp(param->rmt_srvcs.bda, p_dev->bda, ESP_BD_ADDR_LEN) == 0 &&
-                p_dev->state == APP_GAP_STATE_SERVICE_DISCOVERING) {
-            p_dev->state = APP_GAP_STATE_SERVICE_DISCOVER_COMPLETE;
-            if (param->rmt_srvcs.stat == ESP_BT_STATUS_SUCCESS) {
-                ESP_LOGI(CSHA_TAG, "Services for device %s found",  bda2str(p_dev->bda, bda_str, 18));
-                for (int i = 0; i < param->rmt_srvcs.num_uuids; i++) {
-                    esp_bt_uuid_t *u = param->rmt_srvcs.uuid_list + i;
-                    ESP_LOGI(CSHA_TAG, "--%s", uuid2str(u, uuid_str, 37));
-                    // ESP_LOGI(CSHA_TAG, "--%d", u->len);
-                }
-            } else {
-                ESP_LOGI(CSHA_TAG, "Services for device %s not found",  bda2str(p_dev->bda, bda_str, 18));
+        case ESP_BT_GAP_DISC_STATE_CHANGED_EVT: {
+            if (param->disc_st_chg.state == ESP_BT_GAP_DISCOVERY_STOPPED) {
+                ESP_LOGI(CSHA_TAG, "Device discovery stopped.");
+                //if ( (p_dev->state == APP_GAP_STATE_DEVICE_DISCOVER_COMPLETE ||
+                //        p_dev->state == APP_GAP_STATE_DEVICE_DISCOVERING)
+                //        && p_dev->dev_found) {
+                //    p_dev->state = APP_GAP_STATE_SERVICE_DISCOVERING;
+                //    ESP_LOGI(CSHA_TAG, "Discover services ...");
+                //    esp_bt_gap_get_remote_services(p_dev->bda);
+                //}
+            } else if (param->disc_st_chg.state == ESP_BT_GAP_DISCOVERY_STARTED) {
+                ESP_LOGI(CSHA_TAG, "Discovery started.");
             }
+            break;
         }
-        break;
-    }
-    case ESP_BT_GAP_RMT_SRVC_REC_EVT:
-    default: {
-        ESP_LOGI(CSHA_TAG, "event: %d", event);
-        break;
-    }
+        case ESP_BT_GAP_RMT_SRVCS_EVT: {
+            if (memcmp(param->rmt_srvcs.bda, p_dev->bda, ESP_BD_ADDR_LEN) == 0 &&
+                    p_dev->state == APP_GAP_STATE_SERVICE_DISCOVERING) {
+                p_dev->state = APP_GAP_STATE_SERVICE_DISCOVER_COMPLETE;
+                if (param->rmt_srvcs.stat == ESP_BT_STATUS_SUCCESS) {
+                    ESP_LOGI(CSHA_TAG, "Services for device %s found",  bda2str(p_dev->bda, bda_str, 18));
+                    for (int i = 0; i < param->rmt_srvcs.num_uuids; i++) {
+                        esp_bt_uuid_t *u = param->rmt_srvcs.uuid_list + i;
+                        ESP_LOGI(CSHA_TAG, "--%s", uuid2str(u, uuid_str, 37));
+                        // ESP_LOGI(CSHA_TAG, "--%d", u->len);
+                    }
+                } else {
+                    ESP_LOGI(CSHA_TAG, "Services for device %s not found",  bda2str(p_dev->bda, bda_str, 18));
+                }
+            }
+            break;
+        }
+        case ESP_BT_GAP_RMT_SRVC_REC_EVT:
+        default: {
+            ESP_LOGI(CSHA_TAG, "event: %d", event);
+            break;
+        }
     }
     return;
 }
 
 void bt_app_gap_start_up(void)
 {
-    get_mac_str(wifi_mac_str);
     while (true) {
-	char *dev_name = "ESP_GAP_INQRUIY";
-	esp_bt_dev_set_device_name(dev_name);
-	
-	/* register GAP callback function */
-	esp_bt_gap_register_callback(bt_app_gap_cb);
-	
-	/* set discoverable and connectable mode, wait to be connected */
-	esp_bt_gap_set_scan_mode(ESP_BT_NON_CONNECTABLE, ESP_BT_NON_DISCOVERABLE);
-	
-	/* inititialize device information and status */
-	bt_app_gap_init();
-	
-	ESP_LOGI(CSHA_TAG, "Begin inquiry");
-	esp_bt_gap_start_discovery(ESP_BT_INQ_MODE_GENERAL_INQUIRY, 10, 0);
-	vTaskDelay(15000 / portTICK_PERIOD_MS);
+	    char *dev_name = "ESP_GAP_INQRUIY";
+	    esp_bt_dev_set_device_name(dev_name);
+	    
+	    /* register GAP callback function */
+	    esp_bt_gap_register_callback(bt_app_gap_cb);
+	    
+	    /* set discoverable and connectable mode, wait to be connected */
+	    esp_bt_gap_set_scan_mode(ESP_BT_NON_CONNECTABLE, ESP_BT_NON_DISCOVERABLE);
+	    
+	    /* inititialize device information and status */
+	    bt_app_gap_init();
+	    
+	    ESP_LOGI(CSHA_TAG, "Begin inquiry");
+	    esp_bt_gap_start_discovery(ESP_BT_INQ_MODE_GENERAL_INQUIRY, 10, 0);
+	    vTaskDelay(15000 / portTICK_PERIOD_MS);
     }
 }
 

--- a/components/bluetooth/bluetooth.c
+++ b/components/bluetooth/bluetooth.c
@@ -1,5 +1,7 @@
 #include "bluetooth.h"
 
+char wifi_mac_str[17];
+
 char *bda2str(esp_bd_addr_t bda, char *str, size_t size)
 {
     if (bda == NULL || str == NULL || size < 18) {
@@ -133,12 +135,7 @@ void update_device_info(esp_bt_gap_cb_param_t *param)
     }
 
     //if (p_dev->eir && p_dev->bdname_len == 0) {
-        get_name_from_eir(p_dev->eir, p_dev->bdname, &p_dev->bdname_len);
-        ESP_LOGI(CSHA_TAG, "Found a target device, address %s, name %s, RSSI %d", bda2str(param->disc_res.bda, bda_str, 18), p_dev->bdname, rssi);
-
-        //p_dev->state = APP_GAP_STATE_DEVICE_DISCOVER_COMPLETE;
-        // We never wanna stop
-//        ESP_LOGI(CSHA_TAG, "Cancel device discovery ...");
+        get_name_from_eir(p_dev->eir, p_dev->bdname, &p_dev->bdname_len); ESP_LOGI(CSHA_TAG, "Found a target device, address %s, name %s, RSSI %d", bda2str(param->disc_res.bda, bda_str, 18), p_dev->bdname, rssi); //p_dev->state = APP_GAP_STATE_DEVICE_DISCOVER_COMPLETE; // We never wanna stop //        ESP_LOGI(CSHA_TAG, "Cancel device discovery ...");
 //       esp_bt_gap_cancel_discovery();
     //}
 }
@@ -206,22 +203,23 @@ void bt_app_gap_cb(esp_bt_gap_cb_event_t event, esp_bt_gap_cb_param_t *param)
 
 void bt_app_gap_start_up(void)
 {
+    get_mac_str(wifi_mac_str);
     while (true) {
-    char *dev_name = "ESP_GAP_INQRUIY";
-    esp_bt_dev_set_device_name(dev_name);
-
-    /* register GAP callback function */
-    esp_bt_gap_register_callback(bt_app_gap_cb);
-
-    /* set discoverable and connectable mode, wait to be connected */
-    esp_bt_gap_set_scan_mode(ESP_BT_NON_CONNECTABLE, ESP_BT_NON_DISCOVERABLE);
-
-    /* inititialize device information and status */
-    bt_app_gap_init();
-
-    ESP_LOGI(CSHA_TAG, "Begin inquiry");
-        esp_bt_gap_start_discovery(ESP_BT_INQ_MODE_GENERAL_INQUIRY, 10, 0);
-    vTaskDelay(15000 / portTICK_PERIOD_MS);
+	char *dev_name = "ESP_GAP_INQRUIY";
+	esp_bt_dev_set_device_name(dev_name);
+	
+	/* register GAP callback function */
+	esp_bt_gap_register_callback(bt_app_gap_cb);
+	
+	/* set discoverable and connectable mode, wait to be connected */
+	esp_bt_gap_set_scan_mode(ESP_BT_NON_CONNECTABLE, ESP_BT_NON_DISCOVERABLE);
+	
+	/* inititialize device information and status */
+	bt_app_gap_init();
+	
+	ESP_LOGI(CSHA_TAG, "Begin inquiry");
+	esp_bt_gap_start_discovery(ESP_BT_INQ_MODE_GENERAL_INQUIRY, 10, 0);
+	vTaskDelay(15000 / portTICK_PERIOD_MS);
     }
 }
 

--- a/components/bluetooth/bluetooth.c
+++ b/components/bluetooth/bluetooth.c
@@ -1,5 +1,6 @@
 #include "bluetooth.h"
 
+static char identifier_mac[17];
 
 char *bda2str(esp_bd_addr_t bda, char *str, size_t size)
 {
@@ -125,29 +126,26 @@ void update_device_info(esp_bt_gap_cb_param_t *param)
 
     get_name_from_eir(p_dev->eir, p_dev->bdname, &p_dev->bdname_len); 
 
-    csha_bt_packet packet;
+    csha_bt_packet btpacket;
 
     ESP_LOGI(CSHA_TAG, "Found a target device, address %s, name %s, RSSI %d", bda2str(param->disc_res.bda, bda_str, 18), p_dev->bdname, rssi);
     
     //copy bda string to bt packet
-    //packet.mac = bda_str;
-    sprintf(packet.mac, "%s", bda_str);
-    sprintf(packet.name, "%s",  p_dev->bdname);
-    packet.rssi = rssi;
+    //btpacket.mac = bda_str;
+    sprintf(btpacket.mac, "%s", bda_str);
+    sprintf(btpacket.name, "%s",  p_dev->bdname);
+    btpacket.rssi = rssi;
 
-    int data_str_len = calc_len(&packet);
+    int data_str_len = calc_len(&btpacket);
     char data_str[data_str_len];
 
-    format_data(data_str, &packet);
+    format_data(data_str, identifier_mac, &btpacket);
 
-    if (socket_ready())
+    if (wifi_connected())
     {
-        // ESP_LOGI(CSHA_TAG,"sending udp");
-        udp_send_str(data_str, MAX_SAFE_BLOCK_SIZE);
+        udp_send_str(data_str, MAX_SAFE_UDP_BLOCK_SIZE);
     }
-    // ESP_LOGI(CSHA_TAG, "%s -- %d", data_str, data_str_len);
 
-    // ESP_LOGI(CSHA_TAG, "%d -- %d -- %d -- %d", data_str_len, strlen((&packet)->name), strlen((&packet)->mac), packet.rssi);
 }
 
 void bt_app_gap_init(void)
@@ -213,6 +211,7 @@ void bt_app_gap_cb(esp_bt_gap_cb_event_t event, esp_bt_gap_cb_param_t *param)
 
 void bt_app_gap_start_up(void)
 {
+    get_wifi_mac_str(identifier_mac);
     while (true) {
 	    char *dev_name = "ESP_GAP_INQRUIY";
 	    esp_bt_dev_set_device_name(dev_name);
@@ -231,4 +230,3 @@ void bt_app_gap_start_up(void)
 	    vTaskDelay(15000 / portTICK_PERIOD_MS);
     }
 }
-

--- a/components/bluetooth/include/bluetooth.h
+++ b/components/bluetooth/include/bluetooth.h
@@ -1,3 +1,6 @@
+#ifndef _BLUETOOTH_H_
+#define _BLUETOOTH_H_
+
 #include <stdint.h>
 #include <string.h>
 #include <math.h>
@@ -52,3 +55,5 @@ void bt_app_gap_init(void);
 void bt_app_gap_cb(esp_bt_gap_cb_event_t event, esp_bt_gap_cb_param_t *param);
 
 void bt_app_gap_start_up(void);
+
+#endif

--- a/components/bluetooth/include/bluetooth.h
+++ b/components/bluetooth/include/bluetooth.h
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include <string.h>
+#include <math.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 //#include "nvs.h"

--- a/components/bluetooth/include/bluetooth.h
+++ b/components/bluetooth/include/bluetooth.h
@@ -11,6 +11,8 @@
 #include "esp_bt_device.h"
 #include "esp_gap_bt_api.h"
 #include "data.h"
+#include "udp.h"
+#include "wifi.h"
 
 #define CSHA_TAG "CSHA Bluetooth"
 

--- a/components/bluetooth/include/bluetooth.h
+++ b/components/bluetooth/include/bluetooth.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <math.h>
+#include <sys/time.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 //#include "nvs.h"
@@ -20,6 +21,9 @@
 
 #define CSHA_TAG "CSHA Bluetooth"
 
+/*
+* possible BLE app states or states 
+*/
 typedef enum {
     APP_GAP_STATE_IDLE = 0,
     APP_GAP_STATE_DEVICE_DISCOVERING,
@@ -28,6 +32,9 @@ typedef enum {
     APP_GAP_STATE_SERVICE_DISCOVER_COMPLETE,
 } app_gap_state_t;
 
+/*
+* all event information passed to BLE app callback 
+*/
 typedef struct {
     bool dev_found;
     uint8_t bdname_len;
@@ -42,18 +49,40 @@ typedef struct {
 
 app_gap_cb_t m_dev_info;
 
+/*
+* format Bluetooth Device Address into string
+* returns pointer to string
+*/
 char *bda2str(esp_bd_addr_t bda, char *str, size_t size);
 
+/*
+* format UUID to string
+*/
 char *uuid2str(esp_bt_uuid_t *uuid, char *str, size_t size);
 
+/* 
+* get string name from Extended Inquiry Response data
+*/
 bool get_name_from_eir(uint8_t *eir, uint8_t *bdname, uint8_t *bdname_len);
 
+/*
+* update detection information to most recent detection data
+*/
 void update_device_info(esp_bt_gap_cb_param_t *param);
 
+/*
+* setup bluetooth application
+*/
 void bt_app_gap_init(void);
 
+/*
+* callback on bluetooth app state change
+*/
 void bt_app_gap_cb(esp_bt_gap_cb_event_t event, esp_bt_gap_cb_param_t *param);
 
+/*
+* start bluetooth application
+*/
 void bt_app_gap_start_up(void);
 
 #endif

--- a/components/data/data.c
+++ b/components/data/data.c
@@ -2,12 +2,26 @@
 #include "data.h"
 
 
-int calc_len(csha_bt_packet* frame)
+int calc_len(time_t timestamp, csha_bt_packet* frame)
 {
-    return strlen(frame->name) + strlen(frame->mac) + (frame->rssi == 0 || frame->rssi == 1 ? 1 : ceil(log10(abs(frame->rssi)))) + (frame->rssi < 0 ? 1:0) + 5 + 18 + 18;
+            // characters for device name
+    return strlen(frame->name) + 
+            // characters required for rssi value
+            (frame->rssi == 0 || frame->rssi == 1 ? 1 : ceil(log10(abs(frame->rssi)))) + 
+            (frame->rssi < 0 ? 1:0) +  //negative takes on extra
+            // characters required for timestamp 
+            (timestamp == 0 ? 1: ceil(log10(timestamp))) +
+            // number of separator characters + characters for mac + characters for mac + 
+            6 + 17 + 17;
 }
-char* format_data(char* str, char* sourcemac, csha_bt_packet* frame)
+char* format_data(char* str, time_t timestamp, char* sourcemac, csha_bt_packet* frame)
 {
-    sprintf(str, "%s%s%s%s%s%s%d%s%s",sourcemac, SEPARATOR, frame->name,SEPARATOR, frame->mac,SEPARATOR, frame->rssi,SEPARATOR,SEPARATOR);
+    sprintf(str, "%s%s%d%s%s%s%s%s%d%s%s",
+            sourcemac, SEPARATOR, 
+            (int) timestamp, SEPARATOR,
+            frame->name,SEPARATOR, 
+            frame->mac,SEPARATOR, 
+            frame->rssi,SEPARATOR,SEPARATOR
+            );
     return str;
 }

--- a/components/data/data.c
+++ b/components/data/data.c
@@ -4,10 +4,10 @@
 
 int calc_len(csha_bt_packet* frame)
 {
-    return strlen(frame->name) + strlen(frame->mac) + (frame->rssi == 0 || frame->rssi == 1 ? 1 : ceil(log10(abs(frame->rssi)))) + (frame->rssi < 0 ? 1:0) + 5 + 18;
+    return strlen(frame->name) + strlen(frame->mac) + (frame->rssi == 0 || frame->rssi == 1 ? 1 : ceil(log10(abs(frame->rssi)))) + (frame->rssi < 0 ? 1:0) + 5 + 18 + 18;
 }
-char* format_data(char* str, csha_bt_packet* frame)
+char* format_data(char* str, char* sourcemac, csha_bt_packet* frame)
 {
-    sprintf(str, "%s%s%s%s%d%s%s", frame->name,SEPARATOR, frame->mac,SEPARATOR, frame->rssi,SEPARATOR,SEPARATOR);
+    sprintf(str, "%s%s%s%s%s%s%d%s%s",sourcemac, SEPARATOR, frame->name,SEPARATOR, frame->mac,SEPARATOR, frame->rssi,SEPARATOR,SEPARATOR);
     return str;
 }

--- a/components/data/data.c
+++ b/components/data/data.c
@@ -1,14 +1,10 @@
 #include <stdio.h>
 #include "data.h"
 
-csha_bt_packet* new_frame()
-{
-    return malloc(sizeof(csha_bt_packet));
-}
 
 int calc_len(csha_bt_packet* frame)
 {
-    return strlen(frame->name) + strlen(frame->mac) + (frame->rssi == 0 || frame->rssi == 1 ? 1 : ceil(log10(frame->rssi))) + 5 + 17;
+    return strlen(frame->name) + strlen(frame->mac) + (frame->rssi == 0 || frame->rssi == 1 ? 1 : ceil(log10(abs(frame->rssi)))) + (frame->rssi < 0 ? 1:0) + 5 + 18;
 }
 char* format_data(char* str, csha_bt_packet* frame)
 {

--- a/components/data/include/data.h
+++ b/components/data/include/data.h
@@ -29,7 +29,7 @@ int calc_len(csha_bt_packet* frame);
 * 
 * returns pointer to str
 */
-char* format_data(char* str, csha_bt_packet* frame);
+char* format_data(char* str, char* sourcemac, csha_bt_packet* frame);
 
 
 

--- a/components/data/include/data.h
+++ b/components/data/include/data.h
@@ -1,6 +1,8 @@
 #ifndef DATA
 #define DATA
 
+#include <string.h>
+#include <math.h>
 
 #define SEPARATOR "|"
 

--- a/components/data/include/data.h
+++ b/components/data/include/data.h
@@ -18,18 +18,18 @@ typedef struct {
 /*
 * returns the length minimum length of a string that can hold the data formatted to send
 */
-int calc_len(csha_bt_packet* frame);
+int calc_len(time_t timestamp, csha_bt_packet* frame);
 
 /*
 * formats detection data and stores it in str
-* formatted as <esp-mac>|<detected-name>|<detected-mac>|<rssi-value>||
+* formatted as <esp-mac>|<timestamp>|<detected-name>|<detected-mac>|<rssi-value>||
 * replace | with defined separator
 *
 * use calc_len to get minimum length of str
 * 
 * returns pointer to str
 */
-char* format_data(char* str, char* sourcemac, csha_bt_packet* frame);
+char* format_data(char* str, time_t timestamp, char* sourcemac, csha_bt_packet* frame);
 
 
 

--- a/components/data/include/data.h
+++ b/components/data/include/data.h
@@ -10,16 +10,10 @@
 * represents detection data of bluetooth device
 */
 typedef struct {
-    char* name;
-    char* mac;
+    char name[100];
+    char mac[18];
     int rssi;
 } csha_bt_packet;
-
-/*
-* a simple malloc helper function 
-* allocates memory for new detection packet and returns pointer to it
-*/
-csha_bt_packet* new_frame();
 
 /*
 * returns the length minimum length of a string that can hold the data formatted to send

--- a/components/udp/include/udp.h
+++ b/components/udp/include/udp.h
@@ -1,14 +1,24 @@
-#ifndef UDP
-#define UDP
+#ifndef _UDP_H_
+#define _UDP_H_
 
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <string.h>
 
-int send_str(int sock, struct sockaddr_in* destaddr, char* msg_str, int block_size);
-struct sockaddr_in* construct_sockaddr_info(struct sockaddr_in* destaddr, char* addr, int port, int af);
+
+static struct sockaddr_in active_dest;
+static int sockfd = -1;
+
+int send_str(char* msg_str, int block_size);
+
+/**
+ * !!! MUST BE CALLED ONCE BEFORE ATTEMPTING TO SEND OVER UDP !!!
+ * returns true on success
+ */
+bool init_udp_socket(char* dest_addr, int dest_port);
 int default_af();
 int get_sockfd();
+bool socket_ready();
 
 #endif

--- a/components/udp/include/udp.h
+++ b/components/udp/include/udp.h
@@ -6,11 +6,13 @@
 #include <arpa/inet.h>
 #include <string.h>
 
+// maximum safe bytes per block for udp packets
+#define MAX_SAFE_BLOCK_SIZE 508
 
 static struct sockaddr_in active_dest;
 static int sockfd = -1;
 
-int send_str(char* msg_str, int block_size);
+int udp_send_str(char* msg_str, int block_size);
 
 /**
  * !!! MUST BE CALLED ONCE BEFORE ATTEMPTING TO SEND OVER UDP !!!

--- a/components/udp/include/udp.h
+++ b/components/udp/include/udp.h
@@ -9,9 +9,6 @@
 // maximum safe bytes per block for udp packets
 #define MAX_SAFE_BLOCK_SIZE 508
 
-static struct sockaddr_in active_dest;
-static int sockfd = -1;
-
 int udp_send_str(char* msg_str, int block_size);
 
 /**

--- a/components/udp/include/udp.h
+++ b/components/udp/include/udp.h
@@ -9,15 +9,36 @@
 // maximum safe bytes per block for udp packets
 #define MAX_SAFE_UDP_BLOCK_SIZE 508
 
+/*
+* send packet containg just a string over UDP
+* can be chunked based on block_size.  No length of string sent will exceed block_size
+* will automatically send full string in appropriately sized chunks
+*/
 int udp_send_str(char* msg_str, int block_size);
 
 /**
- * !!! MUST BE CALLED ONCE BEFORE ATTEMPTING TO SEND OVER UDP !!!
- * returns true on success
- */
+* setup UDP socket on wifi interface
+* sometimes works even without wifi, so not reliable indicator of connection status
+* !!! MUST BE CALLED ONCE BEFORE ATTEMPTING TO SEND OVER UDP !!!
+* returns true on success
+*/
 bool init_udp_socket(char* dest_addr, int dest_port);
+
+/*
+* get index of default Address Family
+*/
 int default_af();
+
+/*
+* get socket file descriptor
+* automatically called in init_udp_socket
+*/
 int get_sockfd();
+
+/* 
+* checks whether socket is open and ready to send data
+* socket can still open without wifi, so not a reliable connection status indicator
+*/
 bool socket_ready();
 
 #endif

--- a/components/udp/include/udp.h
+++ b/components/udp/include/udp.h
@@ -7,7 +7,7 @@
 #include <string.h>
 
 // maximum safe bytes per block for udp packets
-#define MAX_SAFE_BLOCK_SIZE 508
+#define MAX_SAFE_UDP_BLOCK_SIZE 508
 
 int udp_send_str(char* msg_str, int block_size);
 

--- a/components/udp/udp.c
+++ b/components/udp/udp.c
@@ -1,7 +1,7 @@
 #include "udp.h"
 
 
-int send_str(char* msg_str, int block_size)
+int udp_send_str(char* msg_str, int block_size)
 {
     int last_end = 0;
     int len = strlen(msg_str);

--- a/components/udp/udp.c
+++ b/components/udp/udp.c
@@ -1,6 +1,9 @@
 #include "udp.h"
 
 
+static struct sockaddr_in active_dest;
+static int sockfd = -1;
+
 int udp_send_str(char* msg_str, int block_size)
 {
     int last_end = 0;

--- a/components/udp/udp.c
+++ b/components/udp/udp.c
@@ -1,6 +1,7 @@
 #include "udp.h"
 
-int send_str(int sock, struct sockaddr_in* destaddr, char* msg_str, int block_size)
+
+int send_str(char* msg_str, int block_size)
 {
     int last_end = 0;
     int len = strlen(msg_str);
@@ -8,18 +9,20 @@ int send_str(int sock, struct sockaddr_in* destaddr, char* msg_str, int block_si
     {
         if (i - last_end >= block_size || i == len - 1)
         {
-            sendto(sock, &msg_str[last_end],  i-last_end + (i == len - 1 ? 1 : 0), 0, (const struct sockaddr_in*)destaddr, sizeof(*destaddr));
+            sendto(sockfd, &msg_str[last_end],  i-last_end + (i == len - 1 ? 1 : 0), 0, (const struct sockaddr*)&active_dest, sizeof(active_dest));
             last_end = i;
         }
     }
     return 0;
 }
-struct sockaddr_in* construct_sockaddr_info(struct sockaddr_in* destaddr, char* addr, int port, int af)
+bool init_udp_socket(char* dest_addr, int dest_port)
 {
-    inet_pton(af, addr, &destaddr ->sin_addr);
-    destaddr -> sin_port = htons(port);
-    destaddr -> sin_family = af;
-    return destaddr;
+    int af = default_af();
+    inet_pton(af, dest_addr, &active_dest.sin_addr);
+    active_dest.sin_port = htons(dest_port);
+    active_dest.sin_family = af;
+    sockfd = get_sockfd();
+    return sockfd >= 0;
 }
 int get_sockfd() // if returns < 0, something goofed
 {
@@ -28,4 +31,8 @@ int get_sockfd() // if returns < 0, something goofed
 int default_af()
 {
     return AF_INET;
+}
+bool socket_ready()
+{
+    return sockfd >= 0;
 }

--- a/components/wifi/CMakeLists.txt
+++ b/components/wifi/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "wifi.c"
-                    REQUIRES esp_wifi freertos esp_event
+                    REQUIRES esp_wifi freertos esp_event lwip
                     INCLUDE_DIRS "include")

--- a/components/wifi/include/wifi.h
+++ b/components/wifi/include/wifi.h
@@ -9,6 +9,8 @@
 #include <stdint.h>
 #include "esp_system.h"
 
+static char wifi_mac_str[17];
+
 void wifi_event_handler(void* arg, esp_event_base_t event_base,
                                 int32_t event_id, void* event_data);
 void got_ip_event_handler(void* arg, esp_event_base_t event_base,

--- a/components/wifi/include/wifi.h
+++ b/components/wifi/include/wifi.h
@@ -9,13 +9,18 @@
 #include <stdint.h>
 #include "esp_system.h"
 
+#define WIFI_TAG "CSHA Wifi"
+
 static char wifi_mac_str[17];
 
-void wifi_event_handler(void* arg, esp_event_base_t event_base,
-                                int32_t event_id, void* event_data);
-void got_ip_event_handler(void* arg, esp_event_base_t event_base,
-                             int32_t event_id, void* event_data);
-void start_wifi(void);
+void wifi_event_handler(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data);
+
+void got_ip_event_handler(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data);
+
+/*
+* start wifi process and connect to network with given ssid and password
+*/
+void start_wifi(char* wifi_ssid, char* wifi_pass);
 
 /*
 * converts 6 byte mac address to string representation and stores it in str

--- a/components/wifi/include/wifi.h
+++ b/components/wifi/include/wifi.h
@@ -18,13 +18,22 @@
 #define TIME_TAG "CSHA NTP"
 #define NTP_SERVER "pool.ntp.org"
 #define SNTP_MAX_RETRY_COUNT 5
+#define WIFI_MAX_RETRY_ATTEMPTS 2
 
 static char wifi_mac_str[17];
 static struct tm timeinfo = { 0 };
 static bool sntp_setup = false;
 
+/*
+* callback on wifi state change
+* automatically handles connections
+*/
 void wifi_event_handler(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data);
 
+/*
+* callback on successfully acquiring ip from network
+* retries connection WIFI_MAX_RETRY_ATTEMPTS times
+*/
 void got_ip_event_handler(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data);
 
 /*
@@ -48,10 +57,20 @@ char* byte_mac_to_str(char* str, uint8_t* mac);
 */
 char* get_wifi_mac_str(char* str);
 
+/*
+* returns whether wifi is currently connected
+*/
 bool wifi_connected(void);
 
+/*
+* callback on successful SNTP time sync
+*/
 void time_sync_notification_cb(struct timeval* tv);
 
+/*
+* start SNTP time sync
+* will fail without wifi
+*/
 void init_sntp(void);
 
 /*

--- a/components/wifi/include/wifi.h
+++ b/components/wifi/include/wifi.h
@@ -55,7 +55,7 @@ char* byte_mac_to_str(char* str, uint8_t* mac);
 * formatted as 00:00:00:00:00:00
 * returns pointer to str
 */
-char* get_wifi_mac_str(char* str);
+void get_wifi_mac_str(char* str);
 
 /*
 * returns whether wifi is currently connected

--- a/components/wifi/include/wifi.h
+++ b/components/wifi/include/wifi.h
@@ -1,3 +1,6 @@
+#ifndef _WIFI_H_
+#define _WIFI_H_
+
 #include "freertos/FreeRTOS.h"
 #include "freertos/event_groups.h"
 #include "esp_wifi.h"
@@ -8,10 +11,17 @@
 #include <string.h>
 #include <stdint.h>
 #include "esp_system.h"
+#include "esp_sntp.h"
+#include <sys/time.h>
 
 #define WIFI_TAG "CSHA Wifi"
+#define TIME_TAG "CSHA NTP"
+#define NTP_SERVER "pool.ntp.org"
+#define SNTP_MAX_RETRY_COUNT 5
 
 static char wifi_mac_str[17];
+static struct tm timeinfo = { 0 };
+static bool sntp_setup = false;
 
 void wifi_event_handler(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data);
 
@@ -31,9 +41,23 @@ void start_wifi(char* wifi_ssid, char* wifi_pass);
 char* byte_mac_to_str(char* str, uint8_t* mac);
 
 /*
-* extracts ESP's default MAC and stores it in str
+* extracts ESP's default wifi MAC and stores it in str
 * str length be at least 17
 * formatted as 00:00:00:00:00:00
 * returns pointer to str
 */
-char* get_mac_str(char* str);
+char* get_wifi_mac_str(char* str);
+
+bool wifi_connected(void);
+
+void time_sync_notification_cb(struct timeval* tv);
+
+void init_sntp(void);
+
+/*
+* returns true on success, false on failure
+* probably failed because no wifi or sntp not setup yet
+*/
+bool sntp_update_time(void);
+
+#endif

--- a/components/wifi/wifi.c
+++ b/components/wifi/wifi.c
@@ -1,7 +1,6 @@
 #include "wifi.h"
 #include <stdint.h>
 
-#define MAX_RETRY_ATTEMPTS     2
 
 static wifi_config_t wps_ap_creds[MAX_WPS_AP_CRED];
 static int s_ap_creds_num = 0;
@@ -20,7 +19,7 @@ void wifi_event_handler(void* arg, esp_event_base_t event_base, int32_t event_id
         case WIFI_EVENT_STA_DISCONNECTED:
             ESP_LOGI(WIFI_TAG, "WIFI_EVENT_STA_DISCONNECTED");
             connected = false;
-            if (s_retry_num < MAX_RETRY_ATTEMPTS) {
+            if (s_retry_num < WIFI_MAX_RETRY_ATTEMPTS) {
                 esp_wifi_connect();
                 s_retry_num++;
             } else if (ap_idx < s_ap_creds_num) {

--- a/components/wifi/wifi.c
+++ b/components/wifi/wifi.c
@@ -84,7 +84,7 @@ char* byte_mac_to_str(char* str, uint8_t* mac)
 
 char* get_mac_str(char* str)
 {
-    uint8_t* mac;
+    uint8_t mac[6];
     esp_efuse_mac_get_default(mac);
     return byte_mac_to_str(str, mac);
 }

--- a/components/wifi/wifi.c
+++ b/components/wifi/wifi.c
@@ -81,11 +81,12 @@ char* byte_mac_to_str(char* str, uint8_t* mac)
     return str;
 }
 
-char* get_wifi_mac_str(char* str)
+void get_wifi_mac_str(char* str)
 {
     uint8_t mac[6];
     esp_efuse_mac_get_default(mac);
-    return byte_mac_to_str(str, mac);
+    //return byte_mac_to_str(str, mac);
+    return;
 }
 
 bool wifi_connected(void)

--- a/components/wifi/wifi.c
+++ b/components/wifi/wifi.c
@@ -3,12 +3,11 @@
 
 #define MAX_RETRY_ATTEMPTS     2
 
-static const char *TAG = "CSHA Wifi";
 static wifi_config_t wps_ap_creds[MAX_WPS_AP_CRED];
 static int s_ap_creds_num = 0;
 static int s_retry_num = 0;
-static char* ssid = "willardtest";
-static char* pass = "tits12345"; // tits12345
+// static char* ssid = "willardtest";
+// static char* pass = "tits12345"; // tits12345
 
 void wifi_event_handler(void* arg, esp_event_base_t event_base,
                                 int32_t event_id, void* event_data)
@@ -17,24 +16,23 @@ void wifi_event_handler(void* arg, esp_event_base_t event_base,
 
     switch (event_id) {
         case WIFI_EVENT_STA_START:
-            ESP_LOGI(TAG, "WIFI_EVENT_STA_START");
+            ESP_LOGI(WIFI_TAG, "WIFI_EVENT_STA_START");
             break;
         case WIFI_EVENT_STA_DISCONNECTED:
-            ESP_LOGI(TAG, "WIFI_EVENT_STA_DISCONNECTED");
+            ESP_LOGI(WIFI_TAG, "WIFI_EVENT_STA_DISCONNECTED");
             if (s_retry_num < MAX_RETRY_ATTEMPTS) {
                 esp_wifi_connect();
                 s_retry_num++;
             } else if (ap_idx < s_ap_creds_num) {
-                /* Try the next AP credential if first one fails */
-                if (ap_idx < s_ap_creds_num) {
-                    ESP_LOGI(TAG, "Connecting to SSID: %s, Passphrase: %s",
+                /* Try the next AP credential if first one fails */ if (ap_idx < s_ap_creds_num) {
+                    ESP_LOGI(WIFI_TAG, "Connecting to SSID: %s, Passphrase: %s",
                              wps_ap_creds[ap_idx].sta.ssid, wps_ap_creds[ap_idx].sta.password);
                     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wps_ap_creds[ap_idx++]) );
                     esp_wifi_connect();
                 }
                 s_retry_num = 0;
             } else {
-                ESP_LOGI(TAG, "Failed to connect!");
+                ESP_LOGI(WIFI_TAG, "Failed to connect!");
             }
             break;
         default:
@@ -46,12 +44,13 @@ void got_ip_event_handler(void* arg, esp_event_base_t event_base,
                              int32_t event_id, void* event_data)
 {
     ip_event_got_ip_t* event = (ip_event_got_ip_t*) event_data;
-    ESP_LOGI(TAG, "got ip: " IPSTR, IP2STR(&event->ip_info.ip));
+    ESP_LOGI(WIFI_TAG, "got ip: " IPSTR, IP2STR(&event->ip_info.ip));
 }
 
 /*init wifi as sta and start wps*/
-void start_wifi(void)
+void start_wifi(char* wifi_ssid, char* wifi_pass)
 {
+
     ESP_ERROR_CHECK(esp_netif_init());
     ESP_ERROR_CHECK(esp_event_loop_create_default());
     esp_netif_t *sta_netif = esp_netif_create_default_wifi_sta();
@@ -66,10 +65,10 @@ void start_wifi(void)
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
     ESP_ERROR_CHECK(esp_wifi_start());
 
-    memcpy(wps_ap_creds[0].sta.ssid, ssid,
-       strlen(ssid));
-    memcpy(wps_ap_creds[0].sta.password, pass,
-       strlen(pass));
+    memcpy(wps_ap_creds[0].sta.ssid, wifi_ssid,
+       strlen(wifi_ssid));
+    memcpy(wps_ap_creds[0].sta.password, wifi_pass,
+       strlen(wifi_pass));
 
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wps_ap_creds[0]) );
     esp_wifi_connect(); // Use the creds to connect to WiFi

--- a/main/main.c
+++ b/main/main.c
@@ -21,6 +21,7 @@ void app_main(void)
     }
     ESP_ERROR_CHECK( ret );
 
+    // comment out password define in config file to disable wifi connection attempt
     #ifdef WIFI_PASS
         char* wifi_ssid = WIFI_SSID;
         char* wifi_pass = WIFI_PASS;
@@ -32,9 +33,7 @@ void app_main(void)
     ESP_ERROR_CHECK(esp_bt_controller_mem_release(ESP_BT_MODE_BLE));
 
     esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
-    if ((ret = esp_bt_controller_init(&bt_cfg)) != ESP_OK) 
-    {
-        ESP_LOGE(CSHA_TAG, "%s initialize controller failed: %s\n", __func__, esp_err_to_name(ret));
+    if ((ret = esp_bt_controller_init(&bt_cfg)) != ESP_OK) { ESP_LOGE(CSHA_TAG, "%s initialize controller failed: %s\n", __func__, esp_err_to_name(ret));
         return;
     }
 
@@ -65,12 +64,12 @@ void app_main(void)
 
     time_t now = 0;
 
+    // time will only be accurate if SNTP sync was successful (requires wifi for now)
     time(&now);
 
     ESP_LOGI(TIME_TAG, "now : %d", (int)now);
 
     bt_app_gap_start_up();
-    ESP_LOGI("LIGMA", "Done!");
     ESP_LOGI("LIGMA", "Done!");
 }
 

--- a/main/main.c
+++ b/main/main.c
@@ -21,30 +21,37 @@ void app_main(void)
     }
     ESP_ERROR_CHECK( ret );
 
-    char* wifi_ssid = WIFI_SSID;
-    char* wifi_pass = WIFI_PASS;
-    start_wifi(wifi_ssid, wifi_pass);
-    init_udp_socket(DESTINATION_ADDRESS, DESTINATION_PORT);
-
+    #ifdef WIFI_PASS
+        char* wifi_ssid = WIFI_SSID;
+        char* wifi_pass = WIFI_PASS;
+        start_wifi(wifi_ssid, wifi_pass);
+        init_udp_socket(DESTINATION_ADDRESS, DESTINATION_PORT);
+        sntp_update_time();
+    #endif
+    
     ESP_ERROR_CHECK(esp_bt_controller_mem_release(ESP_BT_MODE_BLE));
 
     esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
-    if ((ret = esp_bt_controller_init(&bt_cfg)) != ESP_OK) {
+    if ((ret = esp_bt_controller_init(&bt_cfg)) != ESP_OK) 
+    {
         ESP_LOGE(CSHA_TAG, "%s initialize controller failed: %s\n", __func__, esp_err_to_name(ret));
         return;
     }
 
-    if ((ret = esp_bt_controller_enable(ESP_BT_MODE_CLASSIC_BT)) != ESP_OK) {
+    if ((ret = esp_bt_controller_enable(ESP_BT_MODE_CLASSIC_BT)) != ESP_OK) 
+    {
         ESP_LOGE(CSHA_TAG, "%s enable controller failed: %s\n", __func__, esp_err_to_name(ret));
         return;
     }
 
-    if ((ret = esp_bluedroid_init()) != ESP_OK) {
+    if ((ret = esp_bluedroid_init()) != ESP_OK) 
+    {
         ESP_LOGE(CSHA_TAG, "%s initialize bluedroid failed: %s\n", __func__, esp_err_to_name(ret));
         return;
     }
 
-    if ((ret = esp_bluedroid_enable()) != ESP_OK) {
+    if ((ret = esp_bluedroid_enable()) != ESP_OK) 
+    {
         ESP_LOGE(CSHA_TAG, "%s enable bluedroid failed: %s\n", __func__, esp_err_to_name(ret));
         return;
     }
@@ -53,9 +60,14 @@ void app_main(void)
 	    ESP_LOGE(CSHA_TAG, "Could not start UDP socket");
     }
 
-    get_mac_str(wifi_mac_str);
+    get_wifi_mac_str(wifi_mac_str);
     ESP_LOGI(WIFI_TAG," mac: %s",  wifi_mac_str);
 
+    time_t now = 0;
+
+    time(&now);
+
+    ESP_LOGI(TIME_TAG, "now : %d", (int)now);
 
     bt_app_gap_start_up();
     ESP_LOGI("LIGMA", "Done!");

--- a/main/main.c
+++ b/main/main.c
@@ -9,7 +9,7 @@
 #include "bluetooth.h"
 #include "udp.h"
 #include "wifi.h"
-#include "socketConfig.h"
+#include "config.h"
 
 void app_main(void)
 {
@@ -21,7 +21,9 @@ void app_main(void)
     }
     ESP_ERROR_CHECK( ret );
 
-    start_wifi();
+    char* wifi_ssid = WIFI_SSID;
+    char* wifi_pass = WIFI_PASS;
+    start_wifi(wifi_ssid, wifi_pass);
     init_udp_socket(DESTINATION_ADDRESS, DESTINATION_PORT);
 
     ESP_ERROR_CHECK(esp_bt_controller_mem_release(ESP_BT_MODE_BLE));
@@ -52,7 +54,7 @@ void app_main(void)
     }
 
     get_mac_str(wifi_mac_str);
-    ESP_LOGI("WIFI"," mac: %s",  wifi_mac_str);
+    ESP_LOGI(WIFI_TAG," mac: %s",  wifi_mac_str);
 
 
     bt_app_gap_start_up();

--- a/main/main.c
+++ b/main/main.c
@@ -33,7 +33,8 @@ void app_main(void)
     ESP_ERROR_CHECK(esp_bt_controller_mem_release(ESP_BT_MODE_BLE));
 
     esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
-    if ((ret = esp_bt_controller_init(&bt_cfg)) != ESP_OK) { ESP_LOGE(CSHA_TAG, "%s initialize controller failed: %s\n", __func__, esp_err_to_name(ret));
+    if ((ret = esp_bt_controller_init(&bt_cfg)) != ESP_OK) {
+        ESP_LOGE(CSHA_TAG, "%s initialize controller failed: %s\n", __func__, esp_err_to_name(ret));
         return;
     }
 

--- a/main/main.c
+++ b/main/main.c
@@ -48,12 +48,15 @@ void app_main(void)
     }
     if (!socket_ready())
     {
-	ESP_LOGE(CSHA_TAG, "Could not start UDP socket");
+	    ESP_LOGE(CSHA_TAG, "Could not start UDP socket");
     }
-    else ESP_LOGE(CSHA_TAG, "UDP socket OPENED!!!");
+
+    get_mac_str(wifi_mac_str);
+    ESP_LOGI("WIFI"," mac: %s",  wifi_mac_str);
 
 
     bt_app_gap_start_up();
     ESP_LOGI("LIGMA", "Done!");
     ESP_LOGI("LIGMA", "Done!");
 }
+

--- a/main/main.c
+++ b/main/main.c
@@ -7,7 +7,9 @@
 #include "esp_log.h"
 
 #include "bluetooth.h"
+#include "udp.h"
 #include "wifi.h"
+#include "socketConfig.h"
 
 void app_main(void)
 {
@@ -20,6 +22,7 @@ void app_main(void)
     ESP_ERROR_CHECK( ret );
 
     start_wifi();
+    init_udp_socket(DESTINATION_ADDRESS, DESTINATION_PORT);
 
     ESP_ERROR_CHECK(esp_bt_controller_mem_release(ESP_BT_MODE_BLE));
 
@@ -43,6 +46,12 @@ void app_main(void)
         ESP_LOGE(CSHA_TAG, "%s enable bluedroid failed: %s\n", __func__, esp_err_to_name(ret));
         return;
     }
+    if (!socket_ready())
+    {
+	ESP_LOGE(CSHA_TAG, "Could not start UDP socket");
+    }
+    else ESP_LOGE(CSHA_TAG, "UDP socket OPENED!!!");
+
 
     bt_app_gap_start_up();
     ESP_LOGI("LIGMA", "Done!");

--- a/main/socketConfig.h
+++ b/main/socketConfig.h
@@ -1,0 +1,7 @@
+#ifndef _SOCKETCONFIG_H_
+#define _SOCKETCONFIG_H_
+
+#define DESTINATION_ADDRESS "129.21.131.22"
+#define DESTINATION_PORT 6666
+
+#endif

--- a/main/templateconfig.h
+++ b/main/templateconfig.h
@@ -1,12 +1,13 @@
 /*
 * copy to config.h and add secrets
 */
-#ifndef _SOCKETCONFIG_H_
-#define _SOCKETCONFIG_H_
+#ifndef _CONFIG_H_
+#define _CONFIG_H_
 
 #define DESTINATION_ADDRESS "129.21.131.22"
 #define DESTINATION_PORT 6666
 
+// to disable wifi connection, comment out defining a password
 #define WIFI_SSID "ssid_here"
 #define WIFI_PASS "password_here"
 

--- a/main/templateconfig.h
+++ b/main/templateconfig.h
@@ -4,10 +4,11 @@
 #ifndef _CONFIG_H_
 #define _CONFIG_H_
 
-#define DESTINATION_ADDRESS "129.21.131.22"
-#define DESTINATION_PORT 6666
+#define DESTINATION_ADDRESS "server_ip_here"
+#define DESTINATION_PORT port_number_here
 
 // to disable wifi connection, comment out defining a password
+// without wifi, node will need to connect to BLE mesh.
 #define WIFI_SSID "ssid_here"
 #define WIFI_PASS "password_here"
 

--- a/main/templateconfig.h
+++ b/main/templateconfig.h
@@ -1,7 +1,13 @@
+/*
+* copy to config.h and add secrets
+*/
 #ifndef _SOCKETCONFIG_H_
 #define _SOCKETCONFIG_H_
 
 #define DESTINATION_ADDRESS "129.21.131.22"
 #define DESTINATION_PORT 6666
+
+#define WIFI_SSID "ssid_here"
+#define WIFI_PASS "password_here"
 
 #endif


### PR DESCRIPTION
UDP data packets can stream to server of choice, only ip for now, maybe name resolution in the future. Automatically time syncs over NTP on startup. wifi connection and data server address configurable through config.h header file. Data packet format : 
 <esp-mac>|<timestamp>|<detected-name>|<detected-mac>|<rssi-value>||