### PR TITLE
Add templating for more devices, change mnt dir

### DIFF
--- a/HACKING/launch-environment.sh
+++ b/HACKING/launch-environment.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 IMAGINE_DIR=/home/$USER/Code/ImagineRIT2022
+DEVICE0=/dev/ttyUSB0
+# DEVICE1=/dev/ttyUSB1 # --device="$DEVICE1":"$DEVICE1":rwm          \
+# DEVICE2=/dev/ttyUSB2 # --device="$DEVICE2":"$DEVICE2":rwm          \
+
 mkdir -p "$IMAGINE_DIR"
 podman run --rm -it                             \
     --name=imaginerit-embedded-dev              \
-    --device=/dev/ttyUSB0:/dev/ttyUSB0:rwm      \
-    -v "$IMAGINE_DIR":/mnt/ImagineRIT2022       \
+    --device="$DEVICE0":"$DEVICE0":rwm          \
+    -v "$IMAGINE_DIR":/ImagineRIT2022           \
     --group-add keep-groups                     \
     --annotation io.crun.keep_original_groups=1 \
-    imaginerit-embedded-dev:v0.0.1
-#podman exec -it imaginerit-embedded-dev bash
+    imaginerit-embedded-dev


### PR DESCRIPTION
Improvements to the container environment. The working directory is now
just in / instead of /mnt, and device parameters been parameterized.